### PR TITLE
Enhanced path parsing + integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,12 @@ Short-term roadmap:
 - [ ] Support recursive path expansion for query parameters
 - [x] Support recursive path expansion for body parameters
 - [x] `additional_bindings` support
-- [ ] Support for wildcard `*` and `**` path expansion
-- [ ] Other support for one-level path expansion as specified by [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.3)
+- [x] Support for wildcard `*` and `**` anonymous/named path expansion
 - [ ] `response_body` support
 - [ ] Performance tests
 - [ ] Generic/pluggable error handling
 - [ ] [possible] supporting streaming RPCs
-- [ ] Publishing to Maven Central
+- [x] Publishing to Maven Central (Sonatype Snapshots currently)
 
 ## Build Process
 

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,8 @@ project(":protoc-gen-jersey") {
         compile "io.grpc:grpc-protobuf:${grpcVersion}"
         compile "io.grpc:grpc-stub:${grpcVersion}"
         compile "com.github.spullara.mustache.java:compiler:0.9.4"
+
+        testCompile 'org.glassfish.jersey.core:jersey-common:2.24.1'
     }
 
     protobuf {

--- a/build.gradle
+++ b/build.gradle
@@ -205,3 +205,52 @@ project(":protoc-gen-jersey") {
     buildArtifacts.dependsOn(prependShellStub)
     shadowJar.finalizedBy(prependShellStub)
 }
+
+project(":integration-test") {
+    apply plugin: 'com.google.protobuf'
+
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+
+    compileJava.dependsOn(':protoc-gen-jersey:shadowJar')
+
+    ['java', 'grpc', 'jersey'].each { plugin ->
+        sourceSets.main.java.srcDirs += file("${protobuf.generatedFilesBaseDir}/main/${plugin}");
+        sourceSets.test.java.srcDirs += file("${protobuf.generatedFilesBaseDir}/test/${plugin}");
+    }
+
+    dependencies {
+        compile 'org.slf4j:jul-to-slf4j:1.7.21'
+        testCompile project(':protoc-gen-jersey')
+        testCompile('io.dropwizard:dropwizard-core:1.0.5') {
+            exclude group: 'org.eclipse.jetty'
+        }
+        testCompile('io.dropwizard:dropwizard-testing:1.0.5') {
+            exclude group: 'org.eclipse.jetty'
+        }
+        testCompile 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jetty:2.23.2'
+
+
+    }
+
+    protobuf {
+        protoc {
+            artifact = "com.google.protobuf:protoc:${protobufVersion}"
+        }
+
+        plugins {
+            grpc {
+                artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
+            }
+            jersey {
+                path = 'protoc-gen-jersey/build/protoc-gen-jersey'
+            }
+        }
+        generateProtoTasks {
+            all()*.plugins {
+                grpc {}
+                jersey {}
+            }
+        }
+    }
+}

--- a/integration-test/src/test/java/com/fullcontact/rpc/jersey/EchoTestService.java
+++ b/integration-test/src/test/java/com/fullcontact/rpc/jersey/EchoTestService.java
@@ -1,0 +1,32 @@
+package com.fullcontact.rpc.jersey;
+
+import com.fullcontact.rpc.TestRequest;
+import com.fullcontact.rpc.TestResponse;
+import com.fullcontact.rpc.TestServiceGrpc;
+
+import io.grpc.stub.StreamObserver;
+
+/**
+ * gRPC service that echos the request into the response
+ *
+ * @author Michael Rose (xorlev)
+ */
+public class EchoTestService extends TestServiceGrpc.TestServiceImplBase {
+    @Override
+    public void testMethod(TestRequest request, StreamObserver<TestResponse> responseObserver) {
+        responseObserver.onNext(TestResponse.newBuilder().setRequest(request).build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void testMethod2(TestRequest request, StreamObserver<TestResponse> responseObserver) {
+        responseObserver.onNext(TestResponse.newBuilder().setRequest(request).build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void testMethod3(TestRequest request, StreamObserver<TestResponse> responseObserver) {
+        responseObserver.onNext(TestResponse.newBuilder().setRequest(request).build());
+        responseObserver.onCompleted();
+    }
+}

--- a/integration-test/src/test/java/com/fullcontact/rpc/jersey/Integration.java
+++ b/integration-test/src/test/java/com/fullcontact/rpc/jersey/Integration.java
@@ -1,0 +1,89 @@
+package com.fullcontact.rpc.jersey;
+
+import com.fullcontact.rpc.NestedType;
+import com.fullcontact.rpc.TestRequest;
+import com.fullcontact.rpc.TestResponse;
+import com.fullcontact.rpc.TestServiceGrpcJerseyResource;
+
+import com.google.protobuf.util.JsonFormat;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.ws.rs.client.Entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end Jersey tests
+ *
+ * @author Michael Rose (xorlev)
+ */
+@RunWith(JUnit4.class)
+public class Integration {
+    @ClassRule
+    public static final ResourceTestRule resources =
+        ResourceTestRule.builder()
+                        .addResource(new TestServiceGrpcJerseyResource(new EchoTestService()))
+                        .setTestContainerFactory(new JettyTestContainerFactory())
+                        .build();
+
+    @Test
+    public void testBasicGet() throws Exception {
+        // /users/{s}/{uint3}/{nt.f1}
+        String responseJson = resources.getJerseyTest()
+                                                 .target("/users/string1/1234/abcd")
+                                                 .request()
+                                                 .buildGet()
+                                                 .invoke(String.class);
+
+        TestResponse.Builder responseFromJson = TestResponse.newBuilder();
+        JsonFormat.parser().merge(responseJson, responseFromJson);
+        TestResponse response = responseFromJson.build();
+
+        assertThat(response.getRequest().getS()).isEqualTo("string1");
+        assertThat(response.getRequest().getUint3()).isEqualTo(1234);
+        assertThat(response.getRequest().getNt().getF1()).isEqualTo("abcd");
+    }
+
+    @Test
+    public void testBasicPost() throws Exception {
+        TestRequest request = TestRequest.newBuilder()
+            .setBoolean(true)
+            .setS("Hello")
+            .setNt(NestedType.newBuilder().setF1("World"))
+            .build();
+        String responseJson = resources.getJerseyTest()
+                 .target("/users/")
+                 .request()
+                 .buildPost(Entity.entity(JsonFormat.printer().print(request), "application/json; charset=utf-8"))
+                 .invoke(String.class);
+
+        TestResponse.Builder responseFromJson = TestResponse.newBuilder();
+        JsonFormat.parser().merge(responseJson, responseFromJson);
+        TestResponse response = responseFromJson.build();
+
+        assertThat(response.getRequest()).isEqualTo(request);
+    }
+
+    @Test
+    public void testAdvancedGet() throws Exception {
+        // /users/{s=hello/**}/x/{uint3}/{nt.f1}/*/**/test
+        String responseJson = resources.getJerseyTest()
+                                 .target("/users/hello/string1/test/x/1234/abcd/foo/bar/baz/test")
+                                 .request()
+                                 .buildGet()
+                                 .invoke(String.class);
+
+        TestResponse.Builder responseFromJson = TestResponse.newBuilder();
+        JsonFormat.parser().merge(responseJson, responseFromJson);
+        TestResponse response = responseFromJson.build();
+
+        assertThat(response.getRequest().getS()).isEqualTo("hello/string1/test");
+        assertThat(response.getRequest().getUint3()).isEqualTo(1234);
+        assertThat(response.getRequest().getNt().getF1()).isEqualTo("abcd");
+    }
+}

--- a/integration-test/src/test/java/com/fullcontact/rpc/jersey/IntegrationApp.java
+++ b/integration-test/src/test/java/com/fullcontact/rpc/jersey/IntegrationApp.java
@@ -1,0 +1,23 @@
+package com.fullcontact.rpc.jersey;
+
+import com.fullcontact.rpc.TestServiceGrpcJerseyResource;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+
+/**
+ * Dropwizard App for local testing
+ *
+ * @author Michael Rose (xorlev)
+ */
+public class IntegrationApp extends Application<Configuration> {
+    @Override
+    public void run(Configuration configuration, Environment environment) throws Exception {
+        environment.jersey().register(new TestServiceGrpcJerseyResource(new EchoTestService()));
+    }
+
+    public static void main(String[] args) throws Exception {
+        new IntegrationApp().run(args);
+    }
+}

--- a/integration-test/src/test/proto/test.proto
+++ b/integration-test/src/test/proto/test.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.fullcontact.rpc";
+import "google/api/annotations.proto";
+
+service TestService {
+    rpc TestMethod (TestRequest) returns (TestResponse) {
+        option (google.api.http).get = "/users/{s}/{uint3}/{nt.f1}";
+    }
+    rpc TestMethod2 (TestRequest) returns (TestResponse) {
+        option (google.api.http) = {
+            post: "/users/",
+            body: "*";
+        };
+    }
+    rpc TestMethod3 (TestRequest) returns (TestResponse) {
+        option (google.api.http).get = "/users/{s=hello/**}/x/{uint3}/{nt.f1}/*/**/test";
+    }
+}
+enum TestEnum {
+    FIRST = 0;
+    SECOND = 1;
+}
+message NestedNestedType {
+    repeated string f1 = 1;
+}
+message NestedType {
+    string f1 = 1;
+    NestedNestedType nnt = 2;
+}
+message TestRequest {
+    string s = 1;
+    uint32 uint3 = 2;
+    uint64 uint6 = 3;
+    int32 int3 = 4;
+    int64 int6 = 5;
+    bytes bytearray = 6;
+    bool boolean = 7;
+    float f = 8;
+    double d = 9;
+    TestEnum enu = 10;
+    NestedType nt = 11;
+}
+message TestResponse {
+    TestRequest request = 1;
+}

--- a/jersey-rpc-support/src/main/java/com/fullcontact/rpc/jersey/GrpcErrorUtil.java
+++ b/jersey-rpc-support/src/main/java/com/fullcontact/rpc/jersey/GrpcErrorUtil.java
@@ -68,6 +68,11 @@ public class GrpcErrorUtil {
 
     public static GrpcError throwableToStatus(Throwable t) {
         Status status = Status.fromThrowable(t);
+
+        if(t instanceof InvalidProtocolBufferException) {
+            status = Status.INVALID_ARGUMENT.withCause(t);
+        }
+
         Metadata trailer = Status.trailersFromThrowable(t);
 
         int statusCode = grpcToHttpStatus(status);

--- a/protoc-gen-jersey/src/main/java/com/fullcontact/rpc/jersey/CodeGenerator.java
+++ b/protoc-gen-jersey/src/main/java/com/fullcontact/rpc/jersey/CodeGenerator.java
@@ -67,7 +67,13 @@ public class CodeGenerator {
             // otherwise it's fully qualified
             String protoPackage = fdProto.getPackage();
             for(DescriptorProtos.DescriptorProto d : fdProto.getMessageTypeList()) {
-                lookup.put("." + protoPackage + "." + d.getName(), fd.findMessageTypeByName(d.getName()));
+                String prefix = ".";
+
+                if(!Strings.isNullOrEmpty(protoPackage)) {
+                    prefix += protoPackage + ".";
+                }
+
+                lookup.put(prefix + d.getName(), fd.findMessageTypeByName(d.getName()));
             }
 
             // Find RPC methods with HTTP extensions

--- a/protoc-gen-jersey/src/main/java/com/fullcontact/rpc/jersey/PathParser.java
+++ b/protoc-gen-jersey/src/main/java/com/fullcontact/rpc/jersey/PathParser.java
@@ -1,0 +1,360 @@
+package com.fullcontact.rpc.jersey;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.Value;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Parser for google.api.http path language
+ *
+ * Template = "/" Segments [ Verb ] ;
+ * Segments = Segment { "/" Segment } ;
+ * Segment  = "*" | "**" | LITERAL | Variable ;
+ * Variable = "{" FieldPath [ "=" Segments ] "}" ;
+ * FieldPath = IDENT { "." IDENT } ;
+ * Verb     = ":" LITERAL ;
+ *
+ * Parser supports all but the "Verb" clause which appears to be superfluous.
+ *
+ * Parsed template trees also emit Jersey @PATH compatible paths with invocation of
+ * {@link ParsedPath#toPath()}
+ *
+ * @author Michael Rose (xorlev)
+ */
+public class PathParser {
+    /**
+     * Parse google.api.http path template into a {@link ParsedPath}
+     */
+    public static ParsedPath parse(String path) {
+        Parser parser = new Parser(path);
+
+        List<Segment> segments = new ArrayList<>();
+        while(parser.hasNext()) {
+            Segment segment = parseSegment(parser);
+
+            if(segment != null)
+                segments.add(segment);
+        }
+
+        return new ParsedPath(segments);
+    }
+
+    private static Segment parseSegment(Parser parser) {
+        // '/' is our segment separator
+        if(parser.peek() == '/')
+            parser.next();
+
+        if(!parser.hasNext())
+            return null;
+
+        switch(parser.peek()) {
+            case '{':
+                return parseNamedVariable(parser);
+            case '*':
+                return parseWildcard(parser);
+            default:
+                return parseLiteral(parser);
+        }
+    }
+
+    private static NamedVariable parseNamedVariable(Parser parser) {
+        parser.next(); // consume '{'
+        String name = parser.consumeToSeparator();
+        List<Segment> segments = new ArrayList<>();
+        if(parser.peek() == '=') {
+            parser.next();
+            segments.add(parseSegment(parser));
+
+            // Parse nested segments if available
+            while(parser.peek() == '/') {
+                parser.next();
+                segments.add(parseSegment(parser));
+            }
+        }
+
+        if(parser.peek() == '}') {
+            parser.next();
+        } else {
+            parser.throwException("Expected '}', found: " + parser.peek());
+        }
+
+        return new NamedVariable(name, ImmutableList.copyOf(segments));
+    }
+
+    private static Segment parseWildcard(Parser parser) {
+        parser.next();
+        if(parser.peek() == '*') {
+            parser.next();
+            return GreedyWildcard.INSTANCE;
+        } else {
+            return Wildcard.INSTANCE;
+        }
+    }
+
+    private static Literal parseLiteral(Parser parser) {
+        if(parser.peek() == '/')
+            parser.next();
+
+        if(parser.isSeparator())
+            parser.throwException("Expected literal, found separator: " + parser.peek());
+
+        String literal = parser.consumeToSeparator();
+
+        if(parser.hasNext() && parser.peek() != '/')
+            parser.throwException("Expected '/', found: " + parser.peek());
+
+        return new Literal(literal);
+    }
+
+    /**
+     * Parse state container + helpful utility methods
+     */
+    static class Parser {
+        private static final CharMatcher SEPARATORS = CharMatcher.anyOf("{}/=");
+
+        private char[] buffer;
+        private int position;
+
+        public Parser(String buffer) {
+            this.buffer = buffer.toCharArray();
+        }
+
+        public int position() {
+            return position;
+        }
+
+        public boolean hasNext() {
+            return position < buffer.length;
+        }
+
+        public char peek() {
+            return buffer[position];
+        }
+
+        public char next() {
+            if(!hasNext())
+                throw new ParseException("Buffer overflow, tried to call next() with no remaining characters");
+
+            return buffer[position++];
+        }
+
+        public boolean isSeparator() {
+            return SEPARATORS.matches(peek());
+        }
+
+        public String consumeToSeparator() {
+            StringBuilder sb = new StringBuilder();
+            while(hasNext() && !isSeparator()) {
+                sb.append(next());
+            }
+
+            return sb.toString();
+        }
+
+        public void throwException(String message) {
+            String path = new String(buffer);
+
+            throw new ParseException(
+                "Unexpected character: " + peek() + " at position " + position
+                + " for in: " + path + (message.isEmpty() ? "." : ". " + message)
+            );
+        }
+    }
+
+    /**
+     * Container for a parsed template tree
+     */
+    @Value
+    public static class ParsedPath {
+        ImmutableList<Segment> segments;
+
+        public ParsedPath(Segment... segments) {
+            this(ImmutableList.copyOf(segments));
+        }
+
+        public ParsedPath(Collection<Segment> segments) {
+            this.segments = ImmutableList.copyOf(segments);
+        }
+
+        /**
+         * Visit all top-level segments in ParsedPath. Does not handle nested segments.
+         *
+         * @return visitor provided
+         */
+        public <T extends SegmentVisitor> T visit(T visitor) {
+            for(Segment segment : segments)
+                segment.accept(visitor);
+
+            return visitor;
+        }
+
+        /**
+         * Generates Jersey @PATH compatible path
+         * @throws IllegalArgumentException if parsed path will not correctly map to a Jersey path, e.x. nested named
+         * variables
+         */
+        public String toPath() {
+            return visit(new JerseyPathSegmentVisitor()).toPath();
+        }
+    }
+
+    public static class ParseException extends RuntimeException {
+        public ParseException(String message) {
+            super(message);
+        }
+    }
+
+    public interface SegmentVisitor {
+        void visit(Literal literal);
+        void visit(NamedVariable namedVariable);
+        void visit(GreedyWildcard greedyWildcard);
+        void visit(Wildcard wildcard);
+    }
+
+    public static class JerseyPathSegmentVisitor implements SegmentVisitor {
+        private List<String> pathSegments = new ArrayList<>();
+        private int anonymousParam = 0;
+
+        @Override
+        public void visit(Literal literal) {
+            pathSegments.add(literal.toPath());
+        }
+
+        @Override
+        public void visit(NamedVariable namedVariable) {
+            pathSegments.add(namedVariable.toPath());
+        }
+
+        @Override
+        public void visit(GreedyWildcard greedyWildcard) {
+            pathSegments.add("{" + ++anonymousParam + ": " + greedyWildcard.toPath() + "}");
+        }
+
+        @Override
+        public void visit(Wildcard wildcard) {
+            pathSegments.add("{" + ++anonymousParam + ": " + wildcard.toPath() + "}");
+        }
+
+        public String toPath() {
+            return "/" + Joiner.on('/').join(pathSegments);
+        }
+    }
+
+    public abstract static class EmptySegmentVisitor implements SegmentVisitor {
+        @Override
+        public void visit(Literal literal) {}
+        @Override
+        public void visit(NamedVariable namedVariable) {}
+        @Override
+        public void visit(GreedyWildcard greedyWildcard) {}
+        @Override
+        public void visit(Wildcard wildcard) {}
+    }
+
+    @ToString
+    abstract static class Segment {
+        public abstract void accept(SegmentVisitor visitor);
+        public abstract String toPath();
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper=false)
+    public static class Literal extends Segment {
+        String literal;
+
+        @Override
+        public void accept(SegmentVisitor visitor) {
+            visitor.visit(this);
+        }
+
+        @Override
+        public String toPath() {
+            return literal;
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper=false)
+    public static class GreedyWildcard extends Segment {
+        public static GreedyWildcard INSTANCE = new GreedyWildcard();
+
+        private GreedyWildcard() {}
+
+        @Override
+        public void accept(SegmentVisitor visitor) {
+            visitor.visit(this);
+        }
+
+        @Override
+        public String toPath() {
+            return ".+";
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper=false)
+    public static class Wildcard extends Segment {
+        public static Wildcard INSTANCE = new Wildcard();
+
+        private Wildcard() {}
+
+        @Override
+        public void accept(SegmentVisitor visitor) {
+            visitor.visit(this);
+        }
+
+        @Override
+        public String toPath() {
+            return "[^/]+";
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper=false)
+    public static class NamedVariable extends Segment {
+        @NonNull String name;
+        @NonNull ImmutableList<Segment> segments;
+
+        public NamedVariable(String name) {
+            this(name, Collections.emptyList());
+        }
+
+        public NamedVariable(String name, Segment... segments) {
+            this(name, ImmutableList.copyOf(segments));
+        }
+
+        public NamedVariable(String name, Collection<Segment> segments) {
+            this.name = name;
+            this.segments = ImmutableList.copyOf(segments);
+        }
+
+        @Override
+        public void accept(SegmentVisitor visitor) {
+            visitor.visit(this);
+        }
+
+        @Override
+        public String toPath() {
+            if(segments.isEmpty()) {
+                return "{" + name + "}";
+            } else {
+                if(segments.stream().anyMatch(s -> s instanceof NamedVariable)) {
+                    throw new IllegalArgumentException(
+                        "Jersey @PATH does not support nested named variables: " + this);
+                }
+
+                return "{" + name + ": " + segments.stream().map(Segment::toPath).collect(Collectors.joining("/")) + "}";
+            }
+        }
+    }
+}

--- a/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/CodeGeneratorTest.java
+++ b/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/CodeGeneratorTest.java
@@ -4,6 +4,8 @@ import com.fullcontact.rpc.TestRequest;
 
 import com.google.common.collect.Iterables;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Michael Rose (xorlev)
  */
+@RunWith(JUnit4.class)
 public class CodeGeneratorTest {
     @Test
     public void parsePathParams() throws Exception {

--- a/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/CodeGeneratorTest.java
+++ b/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/CodeGeneratorTest.java
@@ -15,10 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CodeGeneratorTest {
     @Test
     public void parsePathParams() throws Exception {
-        assertThat(CodeGenerator.parsePathParams(TestRequest.getDescriptor(), "/users/{s}/{uint3}/{nt.f1}"))
+        assertThat(CodeGenerator.parsePathParams(TestRequest.getDescriptor(), PathParser.parse("/users/{s}/{uint3}/{nt.f1}")))
             .extracting("name")
             .containsExactly("s", "uint3", "nt.f1");
-        assertThat(CodeGenerator.parsePathParams(TestRequest.getDescriptor(), "/users/{s}/{uint3}/{nt.f1}"))
+        assertThat(CodeGenerator.parsePathParams(TestRequest.getDescriptor(), PathParser.parse("/users/{s}/{uint3}/{nt.f1}")))
             .extracting(x -> Iterables.getLast(x.getFieldDescriptor()).getName())
             .containsExactly("s", "uint3", "f1");
     }

--- a/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/PathParserTest.java
+++ b/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/PathParserTest.java
@@ -50,9 +50,6 @@ public class PathParserTest {
         if(testCase.generatedPath.isPresent()) {
             PathParser.ParsedPath parsed = PathParser.parse(testCase.path);
             UriTemplateParser parser = new UriTemplateParser(parsed.toPath());
-
-            System.out.println(parser.getPattern());
-            System.out.println(parser.getNameToPattern());
         }
 
     }
@@ -61,15 +58,7 @@ public class PathParserTest {
     public static Collection<TestCase> data() {
         List<TestCase> testCases = Lists.newArrayList(
             new TestCase("/resource/{user_id}/{path=hello/{person}}/*/test",
-                         new PathParser.ParsedPath(
-                             new PathParser.Literal("resource"),
-                             new PathParser.NamedVariable("user_id"),
-                             new PathParser.NamedVariable(
-                                 "path",
-                                 new PathParser.Literal("hello"),
-                                 new PathParser.NamedVariable("person")),
-                             PathParser.Wildcard.INSTANCE,
-                             new PathParser.Literal("test"))
+                         null
                          // no url generated: nested is invalid
             ),
             new TestCase("/resource/{user_id}/{path=**}/*/test",

--- a/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/PathParserTest.java
+++ b/protoc-gen-jersey/src/test/java/com/fullcontact/rpc/jersey/PathParserTest.java
@@ -1,0 +1,196 @@
+package com.fullcontact.rpc.jersey;
+
+import com.google.common.collect.Lists;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.glassfish.jersey.uri.internal.UriTemplateParser;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Tests for {@link PathParser}
+ *
+ * @author Michael Rose (xorlev)
+ */
+@RunWith(Parameterized.class)
+public class PathParserTest {
+    private final TestCase testCase;
+
+    public PathParserTest(TestCase testCase) {
+        this.testCase = testCase;
+    }
+
+    @Test
+    public void testParse() throws Exception {
+        try {
+            PathParser.ParsedPath parsed = PathParser.parse(testCase.path);
+
+            assertEquals(testCase.expectedPath, parsed);
+
+            try {
+                assertEquals(testCase.generatedPath.orElse("No generated URL expected"), parsed.toPath());
+            } catch(IllegalArgumentException e) {
+                testCase.generatedPath.ifPresent(s -> fail("Expected URL but IAE generated: " + e.getMessage()));
+            }
+        } catch(PathParser.ParseException e) {
+            testCase.generatedPath.ifPresent(s -> fail(e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testJerseyParse() throws Exception {
+        if(testCase.generatedPath.isPresent()) {
+            PathParser.ParsedPath parsed = PathParser.parse(testCase.path);
+            UriTemplateParser parser = new UriTemplateParser(parsed.toPath());
+
+            System.out.println(parser.getPattern());
+            System.out.println(parser.getNameToPattern());
+        }
+
+    }
+
+    @Parameters(name = "({index}) {0}")
+    public static Collection<TestCase> data() {
+        List<TestCase> testCases = Lists.newArrayList(
+            new TestCase("/resource/{user_id}/{path=hello/{person}}/*/test",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("user_id"),
+                             new PathParser.NamedVariable(
+                                 "path",
+                                 new PathParser.Literal("hello"),
+                                 new PathParser.NamedVariable("person")),
+                             PathParser.Wildcard.INSTANCE,
+                             new PathParser.Literal("test"))
+                         // no url generated: nested is invalid
+            ),
+            new TestCase("/resource/{user_id}/{path=**}/*/test",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("user_id"),
+                             new PathParser.NamedVariable("path", PathParser.GreedyWildcard.INSTANCE),
+                             PathParser.Wildcard.INSTANCE,
+                             new PathParser.Literal("test")),
+                         "/resource/{user_id}/{path: .+}/{1: [^/]+}/test"
+
+            ),
+            new TestCase("/resource/{test.nested.user_id}/{path=**}/*/test",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("test.nested.user_id"),
+                             new PathParser.NamedVariable("path", PathParser.GreedyWildcard.INSTANCE),
+                             PathParser.Wildcard.INSTANCE,
+                             new PathParser.Literal("test")),
+                         "/resource/{test.nested.user_id}/{path: .+}/{1: [^/]+}/test"
+
+            ),
+            new TestCase("/resource/{test.nested.user_id}/{path=hello/**}/*/test",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("test.nested.user_id"),
+                             new PathParser.NamedVariable("path", new PathParser.Literal("hello"), PathParser.GreedyWildcard.INSTANCE),
+                             PathParser.Wildcard.INSTANCE,
+                             new PathParser.Literal("test")),
+                         "/resource/{test.nested.user_id}/{path: hello/.+}/{1: [^/]+}/test"
+
+            ),
+            new TestCase("/ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ/{test.nested.user_id}/{path=hello/**}/*/test",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ"),
+                             new PathParser.NamedVariable("test.nested.user_id"),
+                             new PathParser.NamedVariable("path", new PathParser.Literal("hello"), PathParser.GreedyWildcard.INSTANCE),
+                             PathParser.Wildcard.INSTANCE,
+                             new PathParser.Literal("test")),
+                         "/ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ/{test.nested.user_id}/{path: hello/.+}/{1: [^/]+}/test"
+
+            ),
+            new TestCase("/Приют/{test.nested.user_id}/{path=hello/**}/*/test",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("Приют"),
+                             new PathParser.NamedVariable("test.nested.user_id"),
+                             new PathParser.NamedVariable("path", new PathParser.Literal("hello"), PathParser.GreedyWildcard.INSTANCE),
+                             PathParser.Wildcard.INSTANCE,
+                             new PathParser.Literal("test")),
+                         "/Приют/{test.nested.user_id}/{path: hello/.+}/{1: [^/]+}/test"
+
+            ),
+            new TestCase("/resource/{user_id}/**/*/test",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("user_id"),
+                             PathParser.GreedyWildcard.INSTANCE,
+                             PathParser.Wildcard.INSTANCE,
+                             new PathParser.Literal("test")),
+                         "/resource/{user_id}/{1: .+}/{2: [^/]+}/test"
+
+            ),
+            new TestCase("/resource/{user_id}",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("user_id")),
+                         "/resource/{user_id}"
+
+            ),
+            new TestCase("/resource/{user_id}/",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("user_id")),
+                         "/resource/{user_id}"
+
+            ),
+            new TestCase("/resource/user_id}/",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("user_id"))
+                         // missing '{'
+
+            ),
+            new TestCase("/resource/{user_id/",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource"),
+                             new PathParser.NamedVariable("user_id"))
+                         // missing '}'
+
+            ),
+            new TestCase("/resource",
+                         new PathParser.ParsedPath(
+                             new PathParser.Literal("resource")),
+                         "/resource"
+
+            ),
+            new TestCase("/",
+                         new PathParser.ParsedPath(),
+                         "/"
+
+            )
+        );
+
+        return testCases;
+    }
+
+    @EqualsAndHashCode
+    @ToString
+    static class TestCase {
+        private final String path;
+        private final PathParser.ParsedPath expectedPath;
+        private final Optional<String> generatedPath;
+
+        public TestCase(String path, PathParser.ParsedPath expectedPath) {
+            this(path, expectedPath, null);
+        }
+
+        public TestCase(String path, PathParser.ParsedPath expectedPath, String generatedPath) {
+            this.path = path;
+            this.expectedPath = expectedPath;
+            this.generatedPath = Optional.ofNullable(generatedPath);
+        }
+    }
+}

--- a/protoc-gen-jersey/src/test/proto/test.proto
+++ b/protoc-gen-jersey/src/test/proto/test.proto
@@ -10,10 +10,13 @@ service TestService {
     }
     rpc TestMethod2 (TestRequest) returns (TestResponse) {
         option (google.api.http) = {
-        post: "/users/",
-        body: "*";
-    };
-}
+            post: "/users/",
+            body: "*";
+        };
+    }
+    rpc TestMethod3 (TestRequest) returns (TestResponse) {
+        option (google.api.http).get = "/users/{s=hello/**}/{uint3}/{nt.f1}/*/**/test";
+    }
 }
 enum TestEnum {
     FIRST = 0;

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = 'grpc-jersey'
 
 include 'jersey-rpc-support'
 include 'protoc-gen-jersey'
+include 'integration-test'


### PR DESCRIPTION
Can parse more exotic URL patterns, e.g. `/users/{s=hello/**}/x/{uint3}/{nt.f1}/*/**/test` where `{s=hello/**}` is a nested variable which binds `hello/x/y/z` to `s`.  

There are some limitations here, especially as type information is not passed in, meaning `/users/{s=hello/**}/{uint3}/{nt.f1}/*/**/test` is ambiguous: `/users/hello/world/123/foo/z/y/test` will  bind a string into `uint3`, but a more specific regex could match it correctly.

`*` wildcards and `**` greedy wildcards are now available for use and are valid to use inside a nested variable (e.x. `{s=**}`)

There's now a basic integration suite which generates a test service and runs Jetty in-process to run test HTTP calls against it.