### PR TITLE
RequestParser: nested query param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Short-term roadmap:
 
 - [ ] Documentation
 - [x] Support recursive path expansion for path parameters
-- [ ] Support recursive path expansion for query parameters
+- [x] Support recursive path expansion for query parameters
 - [x] Support recursive path expansion for body parameters
 - [x] `additional_bindings` support
 - [x] Support for wildcard `*` and `**` anonymous/named path expansion

--- a/integration-test/src/test/java/com/fullcontact/rpc/jersey/Integration.java
+++ b/integration-test/src/test/java/com/fullcontact/rpc/jersey/Integration.java
@@ -1,6 +1,7 @@
 package com.fullcontact.rpc.jersey;
 
 import com.fullcontact.rpc.NestedType;
+import com.fullcontact.rpc.TestEnum;
 import com.fullcontact.rpc.TestRequest;
 import com.fullcontact.rpc.TestResponse;
 import com.fullcontact.rpc.TestServiceGrpcJerseyResource;
@@ -73,10 +74,14 @@ public class Integration {
     public void testAdvancedGet() throws Exception {
         // /users/{s=hello/**}/x/{uint3}/{nt.f1}/*/**/test
         String responseJson = resources.getJerseyTest()
-                                 .target("/users/hello/string1/test/x/1234/abcd/foo/bar/baz/test")
-                                 .request()
-                                 .buildGet()
-                                 .invoke(String.class);
+                                       .target("/users/hello/string1/test/x/1234/abcd/foo/bar/baz/test")
+                                       .queryParam("d", 1234.5678)
+                                       .queryParam("enu", "SECOND")
+                                       .queryParam("uint3", "5678") // ensure path param has precedence
+                                       .queryParam("x", "y")
+                                       .request()
+                                       .buildGet()
+                                       .invoke(String.class);
 
         TestResponse.Builder responseFromJson = TestResponse.newBuilder();
         JsonFormat.parser().merge(responseJson, responseFromJson);
@@ -84,6 +89,8 @@ public class Integration {
 
         assertThat(response.getRequest().getS()).isEqualTo("hello/string1/test");
         assertThat(response.getRequest().getUint3()).isEqualTo(1234);
+        assertThat(response.getRequest().getD()).isEqualTo(1234.5678);
+        assertThat(response.getRequest().getEnu()).isEqualTo(TestEnum.SECOND);
         assertThat(response.getRequest().getNt().getF1()).isEqualTo("abcd");
     }
 }

--- a/jersey-rpc-support/src/test/java/com/fullcontact/rpc/jersey/RequestParserTest.java
+++ b/jersey-rpc-support/src/test/java/com/fullcontact/rpc/jersey/RequestParserTest.java
@@ -29,7 +29,7 @@ public class RequestParserTest {
             .put("s", "string")
             .put("bytearray", "string")
             .put("boolean", "true")
-//            .put("nt.f1", "2") TODO(xorlev): support nested queryparam expansion
+            .put("nt.f1", "2")
             .put("uint3", "3000000000")
             .put("int3", "2000000000")
             .put("uint6", "10000000000000000000")
@@ -45,7 +45,7 @@ public class RequestParserTest {
         assertThat(r.getS()).isEqualTo("string");
         assertThat(r.getBytearray().toStringUtf8()).isEqualTo("string");
         assertThat(r.getBoolean()).isTrue();
-//        assertThat(r.getNt().getF1()).isEqualTo("2"); TODO(xorlev): support nested queryparam expansion
+        assertThat(r.getNt().getF1()).isEqualTo("2");
         assertThat(r.getUint3()).isEqualTo(-1294967296); // uint{32,64} are stored "signed" in Java
         assertThat(r.getInt3()).isEqualTo(2000000000);
         assertThat(r.getUint6()).isEqualTo(-8446744073709551616L);


### PR DESCRIPTION
Enables use of query parameters as a means of mapping nested RPC fields.