### PR TITLE
jersey: protojson: include default field values

### DIFF
--- a/jersey-rpc-support/src/main/java/com/fullcontact/rpc/jersey/JerseyStreamObserver.java
+++ b/jersey-rpc-support/src/main/java/com/fullcontact/rpc/jersey/JerseyStreamObserver.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Response;
  * @author Michael Rose (xorlev)
  */
 public class JerseyStreamObserver<V extends Message> implements StreamObserver<V> {
+    private static final JsonFormat.Printer PRINTER = JsonFormat.printer().includingDefaultValueFields();
     private final AsyncResponse asyncResponse;
 
     public JerseyStreamObserver(AsyncResponse asyncResponse) {
@@ -26,7 +27,7 @@ public class JerseyStreamObserver<V extends Message> implements StreamObserver<V
     public void onNext(V value) {
         // TODO, content-negotiated handler
         try {
-            asyncResponse.resume(JsonFormat.printer().print(value));
+            asyncResponse.resume(PRINTER.print(value));
         }
         catch(InvalidProtocolBufferException e) {
             onError(e);


### PR DESCRIPTION
We want to ensure default values are always serialized (e.g. enums) in
the final protojson. Since this is intended to work with other systems
(such as frontends or non-Java systems without compiled protos) we want
to ensure the structure remains relatively the same.

@sypticus 